### PR TITLE
load-binary updated to return local file when remote host is not avai…

### DIFF
--- a/src/load-binary.ts
+++ b/src/load-binary.ts
@@ -1,6 +1,12 @@
 import { initStreaming } from "yoga-wasm-web";
-
+import { loadYogaBase64 } from './load-base64.js'
 export async function loadYoga() {
-  const response = await fetch(`https://coconut-xr.github.io/flex/yoga.wasm`);
-  return initStreaming(response);
+    try{
+        const response = await fetch(`https://coconut-xr.github.io/flex/yoga.wasm`);
+        return initStreaming(response);
+    } catch (error) {
+        console.log("Cannot retrieve yoga.wasm from remote host. Error: " + error);
+        console.log("Returning local yoga.wasm file")
+        return loadYogaBase64();
+    }
 }


### PR DESCRIPTION
…lable

- Update load-binary to return the local base64 version of yoga.wasm when the remote host is not available